### PR TITLE
Handle passing in undefined as an assoc target

### DIFF
--- a/lib/associations/mixin.js
+++ b/lib/associations/mixin.js
@@ -9,7 +9,7 @@ const BelongsTo = require('./belongs-to');
 
 const Mixin = {
   hasMany(target, options) { // testhint options:none
-    if (!target.prototype || !(target.prototype instanceof this.sequelize.Model)) {
+    if (!target || !target.prototype || !(target.prototype instanceof this.sequelize.Model)) {
       throw new Error(this.name + '.hasMany called with something that\'s not a subclass of Sequelize.Model');
     }
 
@@ -33,7 +33,7 @@ const Mixin = {
   },
 
   belongsToMany(targetModel, options) { // testhint options:none
-    if (!targetModel.prototype || !(targetModel.prototype instanceof this.sequelize.Model)) {
+    if (!!targetModel || !targetModel.prototype || !(targetModel.prototype instanceof this.sequelize.Model)) {
       throw new Error(this.name + '.belongsToMany called with something that\'s not a subclass of Sequelize.Model');
     }
 
@@ -77,7 +77,7 @@ const Mixin = {
 // The logic for hasOne and belongsTo is exactly the same
 function singleLinked(Type) {
   return function(target, options) { // testhint options:none
-    if (!target.prototype || !(target.prototype instanceof this.sequelize.Model)) {
+    if (!target, !target.prototype || !(target.prototype instanceof this.sequelize.Model)) {
       throw new Error(this.name + '.' + Utils.lowercaseFirst(Type.toString()) + ' called with something that\'s not a subclass of Sequelize.Model');
     }
 


### PR DESCRIPTION
When using the patterns demonstrated here: https://github.com/sequelize/express-example/blob/master/models/index.js, it's possible to accidentally pass in `undefined` as the target of an association. This results in a stack trace that isn't obvious. Instead, the lines that assume that the target is defined can check that assumption.

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
